### PR TITLE
Add open-browser-webpack-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 node_modules
 dist
+yarn.lock
+

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "gl-matrix": "^3.0.0",
+    "open-browser-webpack-plugin": "^0.0.5",
     "three": "^0.100.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const OpenBrowserPlugin = require('open-browser-webpack-plugin');
 
 module.exports = function (env = {}) {
   const outputPath = path.resolve(__dirname, env.outputPath || 'dist');
@@ -45,6 +46,10 @@ module.exports = function (env = {}) {
         })
       );
     });
+  } else {
+    plugins.push(
+      new OpenBrowserPlugin({url: 'http://localhost:3000'})
+    );
   }
 
   return {


### PR DESCRIPTION
Now the browser can be automatically opened when excuting `npm start` or `npm run chapterX`, listening to port 3000.