### PR TITLE
fix: 清除后颜色判断错误(第一次绿色点击清除 后面简单三角仍为绿色)

### DIFF
--- a/chapter02/check_polygon/app.js
+++ b/chapter02/check_polygon/app.js
@@ -145,6 +145,7 @@ function init() {
   clearBtn.addEventListener('click', () => {
     hintEl.className = '';
     isSimple = true;
+    isConvex = true;
     points.length = 0;
     direction = 0;
   });


### PR DESCRIPTION
第一次判断非简单多边形后 点击清除 重新画 条件判断错误 线条仍为绿色